### PR TITLE
update user-guide url

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,4 @@ Instructions for reporting a vulnerability can be found on the
 Information about supported Metal3 versions can be found on the
 [Supported release versions] page on the Metal3 website.
 
-[Supported release versions]: https://metal3io.netlify.app/version_support.html
+[Supported release versions]: https://book.metal3.io/version_support.html

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -7,8 +7,8 @@ Please do:
 
 In this repository security reports are handled according to the
 Metal3-io project's security policy. For more information about the security
-policy consult the User-Guide [here](https://metal3io.netlify.app/security_policy.html).
+policy consult the User-Guide [here](https://book.metal3.io/security_policy.html).
 
 Security vulnerability fixes can be ported to the currently supported release branches,
-more about the supported releases can be found [here](https://metal3io.netlify.app/version_support.html).
+more about the supported releases can be found [here](https://book.metal3.io/version_support.html).
 


### PR DESCRIPTION
Our user-guide is now properly hosted at https://book.metal3.io/