### PR TITLE
Add Lennart, Adam and Tuomo as approvers and move Furkat to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,12 @@
 
 approvers:
 - dtantsur
-- furkatgofurov7
 - kashifest
+- lentzi90
+- Rozzii
+- tuminoid
 - zaneb
+
+emeritus_approvers:
+- furkatgofurov7
 


### PR DESCRIPTION
This PR adds the following people as approvers
- @lentzi90
- @Rozzii
- @tuminoid

Also moves @furkatgofurov7 to emeritus_approvers since he has changed focus elsewhere and cannot commit continuing as an approver.